### PR TITLE
fix windows compat

### DIFF
--- a/read.go
+++ b/read.go
@@ -46,7 +46,7 @@ func (i *UI) read(opts *readOptions) (string, error) {
 				resultErr = fmt.Errorf("failed to read the input: %s", err)
 			}
 
-			resultStr = strings.TrimSuffix(line, "\n")
+			resultStr = strings.TrimSuffix(line, "\r\n")
 		}
 	}()
 


### PR DESCRIPTION
exact same issue as presented here: https://github.com/tj/go-prompt/commit/0d6b6628b949eeb2e85fd0ab97152656cd3d2d0e

as an example, the current behavior on windows with a select option gives the following error when choosing 2:

> Enter a number (Default is 1): 2
> "2\r" is not a valid input. Answer by a number.